### PR TITLE
Put blocking call into background

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,15 +1,28 @@
-from typing import Union
-from fastapi import FastAPI, Request
+import asyncio
 from fastapi.responses import Response
-from python_ms_core import Core
-
-
+from fastapi import FastAPI, Depends
+from functools import lru_cache
 from src.services.servicebus_service import ServiceBusService
-
-service_bus_instance = ServiceBusService()
-
+from src.config import Config
 
 app = FastAPI()
+
+
+@lru_cache()
+def get_settings():
+    return Config()
+
+
+def start_servicebus_service():
+    # Start the ServiceBusService (blocking call)
+    service = ServiceBusService()
+
+
+@app.on_event("startup")
+async def startup_event(settings: Config = Depends(get_settings)):
+    # Run the ServiceBusService in a background thread using asyncio
+    loop = asyncio.get_event_loop()
+    loop.run_in_executor(None, start_servicebus_service)
 
 
 class OctetStreamResponse(Response):

--- a/src/main.py
+++ b/src/main.py
@@ -37,3 +37,8 @@ def root():
 @app.get('/ping')
 def ping():
     return {'msg': 'Ping Successful'}
+
+
+@app.get('/health')
+def ping():
+    return "I'm healthy !!"


### PR DESCRIPTION
**Problem:** 
`ServiceBusService`  was working fine and responding to the messages and publishing the messages as usual but API endpoints are not working because it was called as a blocking call.

**Solution:**
This solution allows `ServiceBusService` to run continuously in the background without blocking the FastAPI application's main thread. As a result:

The FastAPI application can handle incoming API requests (such as `health` checks) without delay.
The `ServiceBusService` can perform its tasks as usual and ensuring that the system remains functional.

