### PR TITLE
Update osw_qm_calculator_service.py

### DIFF
--- a/src/services/osw_qm_calculator_service.py
+++ b/src/services/osw_qm_calculator_service.py
@@ -89,7 +89,11 @@ class OswQmCalculator:
 
         """
         input_zip.extractall(unzip_folder)
-        input_files = [name for name in os.listdir(unzip_folder) if os.path.isfile(os.path.join(unzip_folder, name))]
+        # walk through and collect all files
+        input_files = []
+        for root, dirs, files in os.walk(unzip_folder):
+            for file in files:
+                input_files.append(os.path.join(root, file))
         return input_files
 
     def parse_and_calculate_quality_metric(self, input_file, algorithm_names):


### PR DESCRIPTION
- Fixes the issue where the service is not able to calculate the quality metric if the zip extracted to directory
- Instead of walking through the top directory, this walks through all the folders and gathers the files.